### PR TITLE
update country code for vatican city

### DIFF
--- a/src/VuePhoneNumberInput/assets/js/phoneCodeCountries.js
+++ b/src/VuePhoneNumberInput/assets/js/phoneCodeCountries.js
@@ -1200,7 +1200,7 @@ const allCountries = [
   [
     'Vatican City (Città del Vaticano)',
     'va',
-    '39',
+    '379',
     1
   ],
   [


### PR DESCRIPTION
country code of vatican city is 379 not 39