### PR TITLE
Dependency libphonenumber-js latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nuxt/"
   ],
   "dependencies": {
-    "libphonenumber-js": "^1.7.51",
+    "libphonenumber-js": "^1.10.6",
     "style-helpers": "^1.0.2",
     "vue": "^2.6.11",
     "vue-virtual-scroller": "^1.0.10"


### PR DESCRIPTION
This resolves some latest numbers being validated wrongly, I tried Australian number starts with 0493 and it is a valid number still showed error.